### PR TITLE
#️⃣ #48 자판기 퍼즐, 지하철 퍼즐 틀렸을 때 데미지 적용

### DIFF
--- a/lostsomething/Source/lostSomething/Private/Puzzle/Train/LSTrainSpawnGimmick.cpp
+++ b/lostsomething/Source/lostSomething/Private/Puzzle/Train/LSTrainSpawnGimmick.cpp
@@ -5,6 +5,7 @@
 #include "lostSomething.h"
 #include "Components/BoxComponent.h"
 #include "Engine/StaticMeshActor.h"
+#include "Engine/DamageEvents.h"
 #include "Puzzle/Train/LSTrain.h"
 #include "Puzzle/Train/LSTrainStep.h"
 #include "LevelTest/Player/LTPlayerCharacter.h"
@@ -16,6 +17,7 @@
 #include "GameFramework/GameModeBase.h"
 #include "Interface/LSQuestInterface.h"
 #include "Quest/LSQuestManager.h"
+#include "Interface/LSTakeDamageInterface.h"
 
 
 // Sets default values
@@ -112,6 +114,7 @@ ALSTrainSpawnGimmick::ALSTrainSpawnGimmick()
 	CorrectGate = -1;
 	CorrectPeopleCount = 2;
 	PuzzleActivateEnum = ELSInteractionEnum::Quest6;
+	DamageAmount = 10.f;
 }
 
 void ALSTrainSpawnGimmick::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -251,6 +254,7 @@ void ALSTrainSpawnGimmick::CheckPuzzleCorrect()
 	else
 	{
 		OnPuzzleCheck.Broadcast(false, CorrectGate);
+		ApplyDamage();
 	}
 }
 
@@ -292,6 +296,37 @@ void ALSTrainSpawnGimmick::PuzzleActivate()
 
 void ALSTrainSpawnGimmick::PuzzleDeactivate()
 {
+
+}
+
+void ALSTrainSpawnGimmick::ApplyDamage()
+{
+	//LS_LOG(LogLS, Log, TEXT("%s"), TEXT("Begin"));
+
+	if (HasAuthority())
+	{
+		for (UBoxComponent* WaitTrigger : WaitTriggers)
+		{
+			TArray<AActor*> OverlapCharacters;
+			WaitTrigger->GetOverlappingActors(OverlapCharacters, ACharacter::StaticClass());
+			if (OverlapCharacters.Num() > 0)
+			{
+				for (AActor* OverlapCharacter : OverlapCharacters)
+				{
+					APawn* OverlapPawn = Cast<APawn>(OverlapCharacter);
+					if (OverlapPawn)
+					{
+						ILSTakeDamageInterface* LSPlayer = Cast<ILSTakeDamageInterface>(OverlapPawn);
+						if (LSPlayer)
+						{
+							FDamageEvent DamageEvent;
+							LSPlayer->TakeDamage(DamageAmount, DamageEvent, nullptr, this);
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 void ALSTrainSpawnGimmick::OnQuestChange(FLSQuestData InQuestData, ELSInteractionEnum InQuestEnum)

--- a/lostsomething/Source/lostSomething/Private/Puzzle/VendingMachine/LSVendingMachine.cpp
+++ b/lostsomething/Source/lostSomething/Private/Puzzle/VendingMachine/LSVendingMachine.cpp
@@ -7,6 +7,7 @@
 #include "Net/UnrealNetwork.h"
 #include "Components/BoxComponent.h"
 #include "Components/StaticMeshComponent.h"
+#include "Engine/DamageEvents.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/GameModeBase.h"
 #include "LevelTest/Player/LTPlayerController.h"
@@ -14,6 +15,7 @@
 #include "Game/LSGameMode.h"
 #include "Puzzle/VendingMachine/LSVendingMachineManager.h"
 #include "Quest/LSQuestManager.h"
+#include "Interface/LSTakeDamageInterface.h"
 
 ALSVendingMachine::ALSVendingMachine()
 {
@@ -77,10 +79,13 @@ ALSVendingMachine::ALSVendingMachine()
 
 	MachineNumber = 0;
 	PuzzleActivateEnum = ELSInteractionEnum::Quest0;
+	DamageAmount = 10.f;
 }
 
 void ALSVendingMachine::BeginPlay()
 {
+	Super::BeginPlay();
+
 	if (HasAuthority())
 	{
 		BindQuestChange();
@@ -95,6 +100,22 @@ void ALSVendingMachine::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Ou
 }
 
 
+void ALSVendingMachine::InteractionProcess(APlayerController* InPlayerController)
+{
+	//LS_LOG(LogLS, Log, TEXT("%s"), TEXT("Begin"));
+
+	if (HasAuthority())
+	{
+		SetCurrentInteractController(InPlayerController);
+	}
+	else
+	{
+		ServerRPCSetCurrentInteractController(InPlayerController);
+	}
+
+	Super::InteractionProcess(InPlayerController);
+}
+
 void ALSVendingMachine::InteractionProcessSiJae()
 {
 	//const TArray<FString>& Scripts = InteractionScriptDataSiJae->GetInteractionScripts(CurrentQuest);
@@ -102,6 +123,8 @@ void ALSVendingMachine::InteractionProcessSiJae()
 	//{
 	//	LS_LOG(LogLS, Log, TEXT("Interaction Script : %s"), *Script);
 	//}
+
+	//LS_LOG(LogLS, Log, TEXT("%s"), TEXT("Begin"));
 
 	if (HasAuthority())
 	{
@@ -220,6 +243,17 @@ void ALSVendingMachine::PuzzleCheck()
 	else
 	{
 		OnVMPuzzleCheck.Execute(false);
+		ApplyDamage();
+	}
+}
+
+void ALSVendingMachine::ApplyDamage()
+{
+	ILSTakeDamageInterface* LSPlayer = Cast<ILSTakeDamageInterface>(CurrentInteractController->GetPawn());
+	if (LSPlayer)
+	{
+		FDamageEvent DamageEvent;
+		LSPlayer->TakeDamage(DamageAmount, DamageEvent, nullptr, this);
 	}
 }
 
@@ -238,4 +272,9 @@ void ALSVendingMachine::MulticastRPCPuzzleActivate_Implementation()
 void ALSVendingMachine::MulticastRPCPuzzleDeactivate_Implementation()
 {
 	PuzzleDeactivate();
+}
+
+void ALSVendingMachine::ServerRPCSetCurrentInteractController_Implementation(APlayerController* InPlayerController)
+{
+	SetCurrentInteractController(InPlayerController);
 }

--- a/lostsomething/Source/lostSomething/Public/Interface/LSTakeDamageInterface.h
+++ b/lostsomething/Source/lostSomething/Public/Interface/LSTakeDamageInterface.h
@@ -24,3 +24,5 @@ class LOSTSOMETHING_API ILSTakeDamageInterface
 public:
 	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, AActor* DamageCauser) = 0;
 };
+
+//#include "Interface/LSTakeDamageInterface.h"

--- a/lostsomething/Source/lostSomething/Public/Puzzle/Train/LSTrainSpawnGimmick.h
+++ b/lostsomething/Source/lostSomething/Public/Puzzle/Train/LSTrainSpawnGimmick.h
@@ -32,6 +32,7 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
+
 //Stage Section
 protected:
 	UPROPERTY(VisibleAnywhere, Category = Stage, Meta = (AllowPrivateAccess = "true"))
@@ -100,12 +101,16 @@ protected:
 	void OnQuestChange(struct FLSQuestData InQuestData, enum ELSInteractionEnum InQuestEnum);
 	void PuzzleActivate();
 	void PuzzleDeactivate();
+	void ApplyDamage();
 
 	UPROPERTY(EditAnywhere, Category="Puzzle")
 	int32 CorrectPeopleCount;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = Puzzle, Meta = (AllowPrivateAccess = "true"))
 	ELSInteractionEnum PuzzleActivateEnum;
+
+	UPROPERTY(EditAnywhere, Category = "Puzzle")
+	float DamageAmount;
 
 
 //Queset Section

--- a/lostsomething/Source/lostSomething/Public/Puzzle/VendingMachine/LSVendingMachine.h
+++ b/lostsomething/Source/lostSomething/Public/Puzzle/VendingMachine/LSVendingMachine.h
@@ -38,6 +38,7 @@ protected:
 
 //Interaction Section
 public:
+	virtual void InteractionProcess(APlayerController* InPlayerController) override;
 	virtual void InteractionProcessSiJae() override;
 	virtual void InteractionProcessIJae() override;
 
@@ -54,6 +55,7 @@ protected:
 //Puzzle Section
 public:
 	FORCEINLINE void SetMachineNumber(int32 InMachineNumber) { MachineNumber = InMachineNumber; }
+	FORCEINLINE void SetCurrentInteractController(APlayerController* InPlayerController) { CurrentInteractController = InPlayerController; }
 	void BindVendingMachine(class ALSVendingMachineManager* InVendingMachineManager);
 
 	UPROPERTY(Replicated, EditAnywhere, BlueprintReadWrite, Category = Puzzle)
@@ -62,6 +64,8 @@ public:
 	FOnVMPuzzleCheckDelegate OnVMPuzzleCheck;
 
 protected:
+	APlayerController* CurrentInteractController;
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Puzzle)
 	int32 MachineNumber;
 
@@ -70,6 +74,9 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Puzzle, Meta = (AllowPrivateAccess = "true"))
 	ELSInteractionEnum PuzzleActivateEnum;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Puzzle, Meta = (AllowPrivateAccess = "true"))
+	float DamageAmount;
+
 	void BindQuestChange();
 	UFUNCTION()
 	void OnQuestChange(struct FLSQuestData InQuestData, enum ELSInteractionEnum InQuestEnum);
@@ -77,6 +84,7 @@ protected:
 	void PuzzleDeactivate();
 	void SetMachineColor(EVendingMachineColor InAnswerColor, int32 InCurrentColorSet);
 	void PuzzleCheck();
+	void ApplyDamage();
 
 
 //RPC Section
@@ -89,4 +97,8 @@ public:
 
 	UFUNCTION(NetMulticast, Unreliable)
 	void MulticastRPCPuzzleDeactivate();
+
+	UFUNCTION(Server, Unreliable)
+	void ServerRPCSetCurrentInteractController(APlayerController* InPlayerController);
+
 };


### PR DESCRIPTION
## 📌 작업 내용
- 자판기 퍼즐, 지하철 퍼즐 틀렸을 때 데미지 적용

## 🔍 PR 타입
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링

## ✅ 변경 사항
-

## ✅ 참고 사항
-

## 📸 작업 미리보기
-

## 🔥 회고
