### PR TITLE
#️⃣ #205 플레이어 합체 후 이동했을 때에만 stamina 감소하도록 수정 완료

### DIFF
--- a/lostsomething/Source/lostSomething/Private/Character/Players/LSPlayer.cpp
+++ b/lostsomething/Source/lostSomething/Private/Character/Players/LSPlayer.cpp
@@ -2250,6 +2250,28 @@ void ALSPlayer::DecreaseCombineStamina()
 
 	if (!HasAuthority() || !bIsCombining) return;
 
+	// 시제 캐릭터의 속도를 체크하여 decrease 할 수 있도록 추가
+	if (CharacterChoice == ELSCharacterChoice::SiJae)
+	{
+		float CurrentSpeed = GetVelocity().Size();
+
+		// 만일 합체 이후에 움직인 후 가만히 있을 경우 스태미나는 다시 채워짐.
+		// 대신 이때는 스태미나가 채워지는 속도를 느리게 뒀음.
+		if (CurrentSpeed < 10.0f)
+		{
+			CurrentCombineStamina = FMath::Min(MaxCombineStamina, CurrentCombineStamina + (CombineStaminaIncreaseRate * 0.5f) * 0.1f);
+			if (IsLocallyControlled())
+			{
+				UpdateCombineStaminaWidget(CurrentCombineStamina);
+			}
+			else
+			{
+				ClientRPCUpdateCombineStaminaWidget(CurrentCombineStamina);
+			}
+			return;
+		}
+	}
+
 	//이거는 호출되는 변수들의 변경은 있으나 구조는 똑같음.
 	CurrentCombineStamina = FMath::Max(0.0f, CurrentCombineStamina - CombineStaminaDecreaseRate * 0.1f);
 


### PR DESCRIPTION
## 📌 작업 내용
- 플레이어 합체 후 이동했을 때에만 stamina 감소하도록 수정 완료
- 플레이어 합체 후 이동 -> stamina 감소
- 플레이어 합체 후 정지 -> 만일 stamina 감소했을 시 절반 속도로 다시 stamina 회복

## 🔍 PR 타입
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링

## ✅ 변경 사항
-

## ✅ 참고 사항
-

## 📸 작업 미리보기
-

## 🔥 회고
