### PR TITLE
#️⃣ #296 fix : 잡몹 죽는 애니메이션 중 공격 하는 거 막음.

### DIFF
--- a/lostsomething/Source/lostSomething/Private/NPC/Anim/TestNPCAnimIns.cpp
+++ b/lostsomething/Source/lostSomething/Private/NPC/Anim/TestNPCAnimIns.cpp
@@ -65,20 +65,6 @@ void UTestNPCAnimIns::MontageStop(UAnimMontage* Montage, bool bInterrupted)
     Montage_Stop(0.25f, Montage);
 }
 
-void UTestNPCAnimIns::AttackMontagePlay()
-{
-    
-    if (AttackMontage && !Montage_IsPlaying(AttackMontage))
-    {
-        Montage_Play(AttackMontage);
-    }
-    else
-    {
-        UE_LOG(LogTemp, Warning, TEXT("AttackMontage is nullptr in UTestNPCAnimIns"));
-    }
-
-}
-
 void UTestNPCAnimIns::DamageMontagePlay()
 {
     if (DamageMontage && !Montage_IsPlaying(DamageMontage))

--- a/lostsomething/Source/lostSomething/Private/NPC/TestNPC.cpp
+++ b/lostsomething/Source/lostSomething/Private/NPC/TestNPC.cpp
@@ -99,7 +99,7 @@ float ATestNPC::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, 
 
 void ATestNPC::AttackStart()
 {
-	UE_LOG(LogTemp, Warning, TEXT("ATestNPC::AttackByAI()"));
+	//UE_LOG(LogTemp, Warning, TEXT("ATestNPC::AttackByAI()"));
 	ServerAttackStart();
 }
 
@@ -110,7 +110,7 @@ void ATestNPC::ServerAttackStart_Implementation()
 
 void ATestNPC::MultiAttackStart_Implementation()
 {
-	UE_LOG(LogTemp, Warning, TEXT("ATestNPC::MultiAttack_Implementation()"));
+	//UE_LOG(LogTemp, Warning, TEXT("ATestNPC::MultiAttack_Implementation()"));
 
 	UAnimInstance* AnimInstance = GetMesh()->GetAnimInstance();
 	UTestNPCAnimIns* NPCAnimInstance = Cast<UTestNPCAnimIns>(AnimInstance);
@@ -276,6 +276,11 @@ void ATestNPC::MultiDespawn_Implementation()
 	UAnimInstance* AnimInstance = GetMesh()->GetAnimInstance();
 	UTestNPCAnimIns* NPCAnimInstance = Cast<UTestNPCAnimIns>(AnimInstance);
 	if (!NPCAnimInstance || !NPCAnimInstance->DespawnMontage) return;
+
+	if (ATestNPCAIController* PC = Cast<ATestNPCAIController>(GetController()))
+	{
+		PC->StopAI();
+	}
 
 	// 몽타주가 재생 중일 경우 섹션 이동, 아니라면 재생
 	if (NPCAnimInstance->DespawnMontage)

--- a/lostsomething/Source/lostSomething/Public/NPC/Anim/TestNPCAnimIns.h
+++ b/lostsomething/Source/lostSomething/Public/NPC/Anim/TestNPCAnimIns.h
@@ -22,9 +22,6 @@ public:
 	virtual void NativeUpdateAnimation(float DeltaSeconds) override;
 
 	UFUNCTION()
-	void AttackMontagePlay();
-
-	UFUNCTION()
 	void DamageMontagePlay();
 
 	UFUNCTION()


### PR DESCRIPTION
## 📌 작업 내용
- 잡몹 죽는 애니메이션 중 공격 하는 거 막음.

## 🔍 PR 타입
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 리팩토링

## ✅ 변경 사항
-

## ✅ 참고 사항
-

## 📸 작업 미리보기
-

## 🔥 회고
